### PR TITLE
Add action to deploy to prod

### DIFF
--- a/.github/workflows/sigma-deploy.yml
+++ b/.github/workflows/sigma-deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy Sigma Detectors to ELK Prod
+
+# Trigger when a new tag is pushed
+# Tags must follow the format v1.2.3
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+# Use GitHub-hosted runners
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Install Sigma CLI and dependencies
+      run: |
+        sudo apt-get update && sudo apt-get install -y jq python3 python3-pip
+        pip3 install sigma-cli
+
+    - name: Validate rules
+      run: |
+        sigma check sigma
+
+    - name: Install Sigma CLI Elasticsearch backend
+      run: |
+        sigma plugin install elasticsearch
+
+    - name: Convert Sigma rules and output to NDJSON
+      run: |
+        sigma convert -t lucene -f siem_rule_ndjson -p ecs_windows -o rules.ndjson sigma
+
+    - name: Post-process rules in NDJSON
+      run: |
+        python3 scripts/post-process.py
+
+    - name: Deploy rules to ELK via Detections API
+      env:
+        NGROK_URL: ${{ secrets.NGROK_URL }}
+        NGROK_USER: ${{ secrets.NGROK_USER }}
+        NGROK_PASS: ${{ secrets.NGROK_PASS }}
+      run: |
+        curl -sS --user "$NGROK_USER:$NGROK_PASS" \
+          -X POST "$NGROK_URL/api/detection_engine/rules/_import?overwrite=true" \
+          -H 'Content-Type: multipart/form-data' \
+          -H "kbn-xsrf: true" \
+          --form "file=@rules.ndjson" \
+          | jq -e '.success == true and .errors == []'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v1.0.1 Added Scripts folder 
 - v1.0.1 Added post-process python script to ensure correct fields and rule formatting.
 - v1.0.1 Added Workflow to automatically validate Sigma rules when changes are pushed to a branch that isnt main or a PR with base main is opened or updated.
+- v1.0.1 Added Workflow to convert into ELK-compliant ndjson file and push rules to prod  when new release tag is pushed.
 
 ### Changed
 


### PR DESCRIPTION
Added workflow to validate Sigma rules, convert them into ELK-compliant ndjson and deploy to production. Triggered when a new release tag is created.